### PR TITLE
feature: add optional mTLS and separate public/private API

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,14 +13,36 @@ const (
 	port = 8443
 )
 
-func mTLSMiddleware(next http.Handler) http.Handler {
+func mTLSMiddleware(clientCAs *x509.CertPool, verifyPeerCertificate func(*x509.Certificate) error, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
 			http.Error(w, "required client certificate", http.StatusUnauthorized)
 			return
 		}
 
-		fmt.Println(r.TLS.PeerCertificates[0].Subject.CommonName)
+		opts := x509.VerifyOptions{
+			Intermediates: x509.NewCertPool(),
+			Roots:         clientCAs,
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		}
+
+		for _, cert := range r.TLS.PeerCertificates[1:] {
+			opts.Intermediates.AddCert(cert)
+		}
+
+		cert := r.TLS.PeerCertificates[0]
+
+		if _, err := cert.Verify(opts); err != nil {
+			http.Error(w, "failed to verify certificate: "+err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		if verifyPeerCertificate != nil {
+			if err := verifyPeerCertificate(cert); err != nil {
+				http.Error(w, "failed to verify peer certificate: "+err.Error(), http.StatusUnauthorized)
+				return
+			}
+		}
 
 		next.ServeHTTP(w, r)
 	})
@@ -32,21 +54,21 @@ func ping(w http.ResponseWriter, _ *http.Request) {
 }
 
 func main() {
-	handler := http.NewServeMux()
-	handler.Handle("GET /ping", mTLSMiddleware(http.HandlerFunc(ping)))
-
 	clientCaCertPool := x509.NewCertPool()
 	clientCaCertPem, err := os.ReadFile("./cert/client-ca.pem")
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	if !clientCaCertPool.AppendCertsFromPEM(clientCaCertPem) {
 		log.Fatal("failed to append certs from pem")
 	}
 
+	handler := http.NewServeMux()
+	handler.Handle("GET /ping", mTLSMiddleware(clientCaCertPool, nil, http.HandlerFunc(ping)))
+
 	tlsCfg := &tls.Config{
-		ClientCAs:  clientCaCertPool,
-		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientAuth: tls.RequestClientCert,
 	}
 
 	srv := http.Server{

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -48,9 +48,14 @@ func mTLSMiddleware(clientCAs *x509.CertPool, verifyPeerCertificate func(*x509.C
 	})
 }
 
-func ping(w http.ResponseWriter, _ *http.Request) {
+func privatePing(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("pong"))
+	w.Write([]byte("private pong"))
+}
+
+func publicPing(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("public pong"))
 }
 
 func main() {
@@ -65,7 +70,9 @@ func main() {
 	}
 
 	handler := http.NewServeMux()
-	handler.Handle("GET /ping", mTLSMiddleware(clientCaCertPool, nil, http.HandlerFunc(ping)))
+	handler.Handle("GET /private/ping", mTLSMiddleware(clientCaCertPool, nil, http.HandlerFunc(privatePing)))
+
+	handler.Handle("GET /public/ping", http.HandlerFunc(publicPing))
 
 	tlsCfg := &tls.Config{
 		ClientAuth: tls.RequestClientCert,


### PR DESCRIPTION
# This PR introduces the following changes:

## 1. Move mTLS verification to middleware

- Replaced stdlib TLS client verification with a custom mTLSMiddleware. 
- Changed TLS config to RequestClientCert to allow middleware-based verification.
- Ensured client behavior remains unchanged while improving flexibility.

## 2. Separate public and private ping endpoints

- `/private/ping` requires mTLS authentication.
- `/public/ping` remains open and accessible without client certificates.

## 3. Enhance client with optional mTLS support

- Introduced CLI flags:
> `--private`: Send request to `/private/ping`
> `--public`: Send request to `/public/ping`
> `--use-mtls`: Enable mTLS by loading client certificate
- Refactored HTTP client setup into setHttpClient for better modularity.